### PR TITLE
Add TebutoSeminarsWidget for seminars embed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 .playwright-mcp
 coverage
+storybook-static

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent notes — @tebuto/react-booking-widget
+
+This package is a **first-class consumer** of the hosted Tebuto widget embeds. Keep it in sync with the tebuto monorepo (`webapp/src/widget/`).
+
+## Sync contract
+
+When the booking or seminars embed contract changes in tebuto (`data-*` attributes, theme options, script URL, container id):
+
+1. Update the matching component here (`TebutoBookingWidget` / `TebutoSeminarsWidget`).
+2. Update Jest tests and Storybook.
+3. Update the README props tables.
+4. Merge/release, then bump the `react-booking-widget/` submodule pointer in the tebuto monorepo.
+
+Source of truth for attribute names: `webapp/src/widget/booking-render.tsx` and `webapp/src/widget/seminars-render.tsx`.
+
+## Local checks
+
+```bash
+pnpm test
+pnpm lint
+pnpm build
+```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img alt="Tebuto" src="https://tebuto.de/assets/logo.svg" width="400" />
 </div>
 
-<p align="center">A <a href="https://react.dev" target="_blank">React</a> library for integrating <a href="https://tebuto.de" target="_blank">Tebuto</a> appointment booking into your website.</p>
+<p align="center">A <a href="https://react.dev" target="_blank">React</a> library for integrating <a href="https://tebuto.de" target="_blank">Tebuto</a> appointment booking and seminar registration into your website.</p>
 
 <div align="center">
   <a href="https://www.npmjs.com/package/@tebuto/react-booking-widget"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40tebuto%2Freact-booking-widget"></a>
@@ -20,6 +20,8 @@
 - [Widget Configuration](#widget-configuration)
   - [Props Reference](#props-reference)
   - [Theme Configuration](#theme-configuration)
+- [Seminars Widget](#seminars-widget)
+  - [Seminars Props Reference](#seminars-props-reference)
 - [Building Custom Booking UIs](#building-custom-booking-uis)
   - [TebutoProvider](#tebutoprovider)
   - [useBookingFlow Hook](#usebookingflow-hook)
@@ -34,7 +36,8 @@
 
 ## Features
 
-- **Drop-in Widget** - Embed the Tebuto booking widget with a single component
+- **Drop-in Booking Widget** - Embed the Tebuto booking widget with a single component
+- **Drop-in Seminars Widget** - Embed seminar listing and registration the same way
 - **Custom Booking UIs** - Build your own booking interface with powerful React hooks
 - **Full TypeScript Support** - Complete type definitions for all APIs
 - **Theming** - Customize colors, fonts, and styles to match your brand
@@ -119,6 +122,45 @@ function BookingPage() {
 | `borderColor`     | `string`  | Border color                                |
 | `fontFamily`      | `string`  | Font family for the widget                  |
 | `inheritFont`     | `boolean` | Inherit font from parent page               |
+
+## Seminars Widget
+
+Embed seminar listing and registration with the same package:
+
+```tsx
+import { TebutoSeminarsWidget } from "@tebuto/react-booking-widget";
+
+function SeminarsPage() {
+  return (
+    <TebutoSeminarsWidget
+      therapistUUID="your-uuid"
+      seminarSlugs={["einfuehrungsseminar"]}
+      showListFirst={false}
+      theme={{
+        primaryColor: "#00B4A9",
+        backgroundColor: "#ffffff",
+        textPrimary: "#374151",
+        textSecondary: "#6b7280",
+      }}
+    />
+  );
+}
+```
+
+> **Note:** Obtain the therapist UUID and seminar slugs from the seminar embedding section in the Tebuto app (`Seminare` → Buchung).
+
+### Seminars Props Reference
+
+| Prop              | Type                | Required | Default         | Description                                                                 |
+| ----------------- | ------------------- | -------- | --------------- | --------------------------------------------------------------------------- |
+| `therapistUUID`   | `string`            | Yes      | -               | Unique identifier for the therapist                                         |
+| `backgroundColor` | `string`            | No       | `transparent`   | Background color (hex, rgb, etc.)                                           |
+| `seminarSlugs`    | `string[]`          | No       | all seminars    | Filter to these seminar slugs                                               |
+| `border`          | `boolean`           | No       | `true`          | Show border around the widget                                               |
+| `showListFirst`   | `boolean`           | No       | `true`          | When `false` and exactly one seminar is in scope, skip the list             |
+| `inheritFont`     | `boolean`           | No       | `false`         | Use parent page font instead of widget font                                 |
+| `theme`           | `TebutoWidgetTheme` | No       | -               | Theme customization object (same as booking)                                |
+| `noScriptText`    | `string`            | No       | Default message | Text shown when JavaScript is disabled                                      |
 
 ## Building Custom Booking UIs
 
@@ -317,6 +359,7 @@ All types are exported for TypeScript users:
 import type {
   // Configuration
   TebutoBookingWidgetConfiguration,
+  TebutoSeminarsWidgetConfiguration,
   TebutoWidgetTheme,
 
   // API Data
@@ -335,7 +378,6 @@ import type {
   AsyncState,
 } from "@tebuto/react-booking-widget";
 ```
-
 ## License
 
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tebuto/react-booking-widget",
-    "version": "1.3.7",
-    "description": "React Component for the Tebuto Booking Widget",
+    "version": "1.4.0",
+    "description": "React components for the Tebuto booking and seminars widgets",
     "author": "Artus Engineering GmbH",
     "homepage": "https://tebuto.de",
     "license": "MIT",

--- a/src/components/TebutoSeminarsWidget.stories.tsx
+++ b/src/components/TebutoSeminarsWidget.stories.tsx
@@ -1,0 +1,217 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TEBUTO_SEMINARS_WIDGET_SCRIPT_URL } from '../constants'
+import { TebutoSeminarsWidgetConfiguration } from '../types'
+import TebutoSeminarsWidget from './TebutoSeminarsWidget'
+
+function pushThemeAttrs(attrs: string[], theme: NonNullable<TebutoSeminarsWidgetConfiguration['theme']>): void {
+    if (theme.primaryColor) attrs.push(`data-primary-color="${theme.primaryColor}"`)
+    if (theme.textPrimary) attrs.push(`data-text-primary="${theme.textPrimary}"`)
+    if (theme.textSecondary) attrs.push(`data-text-secondary="${theme.textSecondary}"`)
+    if (theme.borderColor) attrs.push(`data-border-color="${theme.borderColor}"`)
+    if (theme.fontFamily) attrs.push(`data-font-family="${theme.fontFamily}"`)
+}
+
+function buildHtmlDataAttributes(config: TebutoSeminarsWidgetConfiguration): string[] {
+    const attrs: string[] = [`data-therapist-uuid="${config.therapistUUID}"`]
+
+    const backgroundColor = config.backgroundColor ?? config.theme?.backgroundColor
+    if (backgroundColor) attrs.push(`data-background-color="${backgroundColor}"`)
+    if (config.seminarSlugs && config.seminarSlugs.length > 0) {
+        attrs.push(`data-seminars="${config.seminarSlugs.join(',')}"`)
+    }
+    if (config.border !== undefined) attrs.push(`data-border="${config.border}"`)
+    if (config.showListFirst !== undefined) attrs.push(`data-show-list-first="${config.showListFirst}"`)
+
+    const inheritFont = config.inheritFont ?? config.theme?.inheritFont
+    if (inheritFont !== undefined) attrs.push(`data-inherit-font="${inheritFont}"`)
+
+    if (config.theme) pushThemeAttrs(attrs, config.theme)
+
+    return attrs
+}
+
+function GeneratedCodePreview(props: Readonly<TebutoSeminarsWidgetConfiguration>) {
+    const attrs = buildHtmlDataAttributes(props)
+    const code = `<div id="tebuto-seminars-widget"></div>
+<script
+  src="${TEBUTO_SEMINARS_WIDGET_SCRIPT_URL}"
+  ${attrs.join('\n  ')}
+></script>`
+
+    return (
+        <div style={{ marginTop: '24px' }}>
+            <h4 style={{ margin: '0 0 12px 0', fontSize: '14px', color: '#374151', fontWeight: 600 }}>Embed Code</h4>
+            <pre
+                style={{
+                    backgroundColor: '#1e1e1e',
+                    color: '#d4d4d4',
+                    padding: '16px',
+                    borderRadius: '8px',
+                    fontSize: '13px',
+                    overflow: 'auto',
+                    margin: 0,
+                    lineHeight: 1.5
+                }}
+            >
+                <code>{code}</code>
+            </pre>
+        </div>
+    )
+}
+
+function WidgetStoryPreview(props: TebutoSeminarsWidgetConfiguration & { showCode?: boolean }) {
+    const { showCode = true, ...widgetProps } = props
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', width: '100%', maxWidth: '960px' }}>
+            <TebutoSeminarsWidget {...widgetProps} />
+            {showCode && <GeneratedCodePreview {...widgetProps} />}
+        </div>
+    )
+}
+
+const DEMO_THERAPIST_UUID = '00000000-0000-0000-0000-000000000000'
+
+const meta: Meta<typeof TebutoSeminarsWidget> = {
+    title: 'Tebuto Seminars Widget',
+    component: TebutoSeminarsWidget,
+    parameters: {
+        layout: 'padded',
+        backgrounds: {
+            default: 'light gray',
+            values: [
+                { name: 'light gray', value: '#f3f4f6' },
+                { name: 'white', value: '#ffffff' },
+                { name: 'dark', value: '#1f2937' }
+            ]
+        },
+        docs: {
+            description: {
+                component: `The Tebuto Seminars Widget embeds seminar listing and registration.
+
+It injects the hosted \`seminars.js\` script with \`data-*\` attributes — the same contract as the HTML snippet and WordPress shortcode.`
+            }
+        }
+    },
+    tags: ['autodocs'],
+    argTypes: {
+        therapistUUID: {
+            control: 'text',
+            description: 'UUID of the therapist (required)',
+            table: { category: 'Required' }
+        },
+        backgroundColor: {
+            control: 'color',
+            description: 'Background color of the widget',
+            table: { category: 'Appearance' }
+        },
+        border: {
+            control: 'boolean',
+            description: 'Show border around the widget',
+            table: { category: 'Appearance' }
+        },
+        seminarSlugs: {
+            control: 'object',
+            description: 'Filter to these seminar slugs',
+            table: { category: 'Filtering' }
+        },
+        showListFirst: {
+            control: 'boolean',
+            description: 'Show seminar list first (false skips list when one seminar)',
+            table: { category: 'Features' }
+        },
+        inheritFont: {
+            control: 'boolean',
+            description: 'Use parent page font instead of widget font',
+            table: { category: 'Appearance' }
+        },
+        theme: {
+            control: 'object',
+            description: 'Custom theme colors and fonts',
+            table: { category: 'Theme' }
+        }
+    },
+    render: args => <WidgetStoryPreview {...args} />
+}
+
+export default meta
+type Story = StoryObj<typeof TebutoSeminarsWidget>
+
+export const Default: Story = {
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        border: true
+    }
+}
+
+export const SingleSeminarSkipList: Story = {
+    name: 'Single seminar (skip list)',
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        seminarSlugs: ['einfuehrungsseminar'],
+        showListFirst: false,
+        border: true
+    }
+}
+
+export const SeminarSelection: Story = {
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        seminarSlugs: ['yoga', 'meditation'],
+        border: true
+    }
+}
+
+export const NoBorder: Story = {
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        border: false
+    }
+}
+
+export const TebutoTheme: Story = {
+    name: 'Theme: Tebuto (Default)',
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        border: true,
+        theme: {
+            primaryColor: '#00B4A9',
+            backgroundColor: '#ffffff',
+            textPrimary: '#374151',
+            textSecondary: '#6b7280',
+            borderColor: '#E9E9E9'
+        }
+    }
+}
+
+export const FullyConfigured: Story = {
+    name: 'Fully Configured',
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        seminarSlugs: ['yoga'],
+        showListFirst: false,
+        inheritFont: true,
+        border: true,
+        theme: {
+            primaryColor: '#6366f1',
+            backgroundColor: '#fafafa',
+            textPrimary: '#18181b',
+            textSecondary: '#71717a',
+            borderColor: '#e4e4e7',
+            fontFamily: '"Inter", system-ui, sans-serif'
+        }
+    }
+}
+
+export const CodeOnly: Story = {
+    name: 'Embed Code Only',
+    render: args => <GeneratedCodePreview {...args} />,
+    args: {
+        therapistUUID: 'YOUR-THERAPIST-UUID',
+        border: true,
+        seminarSlugs: ['mein-seminar'],
+        theme: {
+            primaryColor: '#00B4A9'
+        }
+    }
+}

--- a/src/components/TebutoSeminarsWidget.test.tsx
+++ b/src/components/TebutoSeminarsWidget.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react'
+import { TEBUTO_SEMINARS_WIDGET_NO_SCRIPT_TEXT, TEBUTO_SEMINARS_WIDGET_SCRIPT_URL } from '../constants'
+import TebutoSeminarsWidget from './TebutoSeminarsWidget'
+
+describe('TebutoSeminarsWidget', () => {
+    const therapistUUID = '9fddab56-5dd5-4bc4-b1bd-3b1d52eb952f'
+
+    it('should add a script tag to load the Tebuto Seminars Widget', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} />)
+
+        const container = screen.getByTestId<HTMLDivElement>('tebuto-seminars-widget-container')
+
+        expect(container).not.toBeNull()
+        expect(container.childNodes).toHaveLength(2)
+
+        // @ts-expect-error ts(2339)
+        expect(container.childNodes[0].attributes['data-testid'].value).toBe('tebuto-seminars-widget-script')
+        // @ts-expect-error ts(2339)
+        expect(container.childNodes[1].attributes['data-testid'].value).toBe('tebuto-seminars-widget-noscript')
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script).not.toBeNull()
+        expect(script.src).toBe(TEBUTO_SEMINARS_WIDGET_SCRIPT_URL)
+        expect(script.dataset.therapistUuid).toBe(therapistUUID)
+
+        const noscript = screen.getByTestId('tebuto-seminars-widget-noscript')
+        expect(noscript).not.toBeNull()
+        expect(noscript.textContent).toBe(TEBUTO_SEMINARS_WIDGET_NO_SCRIPT_TEXT)
+    })
+
+    it('should set the "data-background-color" attribute from the backgroundColor prop', () => {
+        const backgroundColor = '#ffffff'
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} backgroundColor={backgroundColor} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.backgroundColor).toBe(backgroundColor)
+    })
+
+    it('should set the "data-border" attribute from the border prop', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} border={false} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.border).toBe('false')
+    })
+
+    it('should set the "data-seminars" attribute from the seminarSlugs prop', () => {
+        const seminarSlugs = ['yoga', 'meditation']
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} seminarSlugs={seminarSlugs} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.seminars).toBe(seminarSlugs.join(','))
+    })
+
+    it('should not set data-seminars when seminarSlugs is empty', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} seminarSlugs={[]} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.seminars).toBeUndefined()
+    })
+
+    it('should set the "data-show-list-first" attribute when showListFirst is false', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} showListFirst={false} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.showListFirst).toBe('false')
+    })
+
+    it('should set the "data-show-list-first" attribute when showListFirst is true', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} showListFirst={true} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.showListFirst).toBe('true')
+    })
+
+    it('should set the noscript text from the noScriptText prop', () => {
+        const noScriptText = 'Custom noscript text'
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} noScriptText={noScriptText} />)
+
+        const noscript = screen.getByTestId('tebuto-seminars-widget-noscript')
+        expect(noscript.textContent).toBe(noScriptText)
+    })
+
+    it('should set the "data-inherit-font" attribute when inheritFont is true', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} inheritFont={true} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.inheritFont).toBe('true')
+    })
+
+    it('should set theme attributes when theme is provided', () => {
+        const theme = {
+            primaryColor: '#3b82f6',
+            textPrimary: '#1e293b',
+            textSecondary: '#64748b',
+            borderColor: '#e2e8f0'
+        }
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} theme={theme} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.primaryColor).toBe(theme.primaryColor)
+        expect(script.dataset.textPrimary).toBe(theme.textPrimary)
+        expect(script.dataset.textSecondary).toBe(theme.textSecondary)
+        expect(script.dataset.borderColor).toBe(theme.borderColor)
+    })
+
+    it('should set all theme attributes when fully configured', () => {
+        const theme = {
+            primaryColor: '#00B4A9',
+            backgroundColor: '#ffffff',
+            textPrimary: '#374151',
+            textSecondary: '#6b7280',
+            borderColor: '#d1d5db',
+            fontFamily: '"Montserrat", sans-serif'
+        }
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} theme={theme} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.primaryColor).toBe(theme.primaryColor)
+        expect(script.dataset.backgroundColor).toBe(theme.backgroundColor)
+        expect(script.dataset.textPrimary).toBe(theme.textPrimary)
+        expect(script.dataset.textSecondary).toBe(theme.textSecondary)
+        expect(script.dataset.borderColor).toBe(theme.borderColor)
+        expect(script.dataset.fontFamily).toBe(theme.fontFamily)
+    })
+
+    it('should prefer top-level backgroundColor over theme.backgroundColor', () => {
+        const topLevelBg = '#ff0000'
+        const themeBg = '#00ff00'
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} backgroundColor={topLevelBg} theme={{ backgroundColor: themeBg }} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.backgroundColor).toBe(topLevelBg)
+    })
+
+    it('should use theme.backgroundColor when top-level backgroundColor is not set', () => {
+        const themeBg = '#00ff00'
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} theme={{ backgroundColor: themeBg }} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.backgroundColor).toBe(themeBg)
+    })
+
+    it('should prefer top-level inheritFont over theme.inheritFont', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} inheritFont={true} theme={{ inheritFont: false }} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.inheritFont).toBe('true')
+    })
+
+    it('should use theme.inheritFont when top-level inheritFont is not set', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} theme={{ inheritFont: true }} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.inheritFont).toBe('true')
+    })
+
+    it('should not set optional attributes when not provided', () => {
+        render(<TebutoSeminarsWidget therapistUUID={therapistUUID} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-seminars-widget-script')
+        expect(script.dataset.therapistUuid).toBe(therapistUUID)
+        expect(script.dataset.backgroundColor).toBeUndefined()
+        expect(script.dataset.seminars).toBeUndefined()
+        expect(script.dataset.border).toBeUndefined()
+        expect(script.dataset.showListFirst).toBeUndefined()
+        expect(script.dataset.inheritFont).toBeUndefined()
+        expect(script.dataset.primaryColor).toBeUndefined()
+    })
+})

--- a/src/components/TebutoSeminarsWidget.tsx
+++ b/src/components/TebutoSeminarsWidget.tsx
@@ -1,0 +1,96 @@
+import { JSX } from 'react'
+import { TEBUTO_SEMINARS_WIDGET_ID, TEBUTO_SEMINARS_WIDGET_NO_SCRIPT_TEXT, TEBUTO_SEMINARS_WIDGET_SCRIPT_URL } from '../constants'
+import { TebutoSeminarsWidgetConfiguration, TebutoWidgetTheme } from '../types'
+
+type TebutoSeminarsWidgetProps = {
+    noScriptText?: string
+} & TebutoSeminarsWidgetConfiguration
+
+export default function TebutoSeminarsWidget({ noScriptText = TEBUTO_SEMINARS_WIDGET_NO_SCRIPT_TEXT, ...config }: TebutoSeminarsWidgetProps): JSX.Element {
+    return (
+        <div id={TEBUTO_SEMINARS_WIDGET_ID} data-testid="tebuto-seminars-widget-container">
+            <TebutoSeminarsWidgetScript config={config} />
+            <noscript data-testid="tebuto-seminars-widget-noscript">{noScriptText}</noscript>
+        </div>
+    )
+}
+
+type DataAttributes = {
+    'data-therapist-uuid': string
+    'data-background-color'?: string
+    'data-seminars'?: string
+    'data-border'?: string
+    'data-show-list-first'?: string
+    'data-inherit-font'?: string
+    'data-primary-color'?: string
+    'data-text-primary'?: string
+    'data-text-secondary'?: string
+    'data-border-color'?: string
+    'data-font-family'?: string
+}
+
+function addBooleanAttributes(attributes: DataAttributes, config: TebutoSeminarsWidgetConfiguration): void {
+    if (config.border !== undefined) {
+        attributes['data-border'] = config.border ? 'true' : 'false'
+    }
+
+    if (config.showListFirst !== undefined) {
+        attributes['data-show-list-first'] = config.showListFirst ? 'true' : 'false'
+    }
+
+    const inheritFont = config.inheritFont ?? config.theme?.inheritFont
+    if (inheritFont !== undefined) {
+        attributes['data-inherit-font'] = inheritFont ? 'true' : 'false'
+    }
+}
+
+function addThemeAttributes(attributes: DataAttributes, theme: TebutoWidgetTheme): void {
+    if (theme.primaryColor) {
+        attributes['data-primary-color'] = theme.primaryColor
+    }
+
+    if (theme.textPrimary) {
+        attributes['data-text-primary'] = theme.textPrimary
+    }
+
+    if (theme.textSecondary) {
+        attributes['data-text-secondary'] = theme.textSecondary
+    }
+
+    if (theme.borderColor) {
+        attributes['data-border-color'] = theme.borderColor
+    }
+
+    if (theme.fontFamily) {
+        attributes['data-font-family'] = theme.fontFamily
+    }
+}
+
+function buildDataAttributes(config: TebutoSeminarsWidgetConfiguration): DataAttributes {
+    const attributes: DataAttributes = {
+        'data-therapist-uuid': config.therapistUUID
+    }
+
+    const backgroundColor = config.backgroundColor ?? config.theme?.backgroundColor
+    if (backgroundColor) {
+        attributes['data-background-color'] = backgroundColor
+    }
+
+    if (config.seminarSlugs && config.seminarSlugs.length > 0) {
+        attributes['data-seminars'] = config.seminarSlugs.join(',')
+    }
+
+    addBooleanAttributes(attributes, config)
+
+    if (config.theme) {
+        addThemeAttributes(attributes, config.theme)
+    }
+
+    return attributes
+}
+
+function TebutoSeminarsWidgetScript({ config }: Readonly<{ config: TebutoSeminarsWidgetConfiguration }>): JSX.Element {
+    const dataAttributes = buildDataAttributes(config)
+
+    return <script src={TEBUTO_SEMINARS_WIDGET_SCRIPT_URL} {...dataAttributes} data-testid="tebuto-seminars-widget-script" />
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as TebutoBookingWidget } from './TebutoBookingWidget'
+export { default as TebutoSeminarsWidget } from './TebutoSeminarsWidget'
 export { CustomBookingExample } from './examples'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,7 @@
 export const TEBUTO_BOOKING_WIDGET_SCRIPT_URL = 'https://widget.tebuto.de/booking.js'
 export const TEBUTO_BOOKING_WIDGET_ID = 'tebuto-booking-widget'
 export const TEBUTO_BOOKING_WIDGET_NO_SCRIPT_TEXT = 'Widget konnte nicht geladen werden. Möglicherweise ist Skripting im Browser deaktiviert.'
+
+export const TEBUTO_SEMINARS_WIDGET_SCRIPT_URL = 'https://widget.tebuto.de/seminars.js'
+export const TEBUTO_SEMINARS_WIDGET_ID = 'tebuto-seminars-widget'
+export const TEBUTO_SEMINARS_WIDGET_NO_SCRIPT_TEXT = 'Seminare-Widget konnte nicht geladen werden. Möglicherweise ist Skripting im Browser deaktiviert.'

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,26 @@ export type TebutoBookingWidgetConfiguration = {
     /** Theme configuration for customizing colors and fonts */
     theme?: TebutoWidgetTheme
 }
+
+/**
+ * Configuration options for the Tebuto Seminars Widget.
+ */
+export type TebutoSeminarsWidgetConfiguration = {
+    /** UUID of the therapist whose seminars should be displayed (required) */
+    therapistUUID: string
+    /** Background color of the widget (shorthand for theme.backgroundColor) */
+    backgroundColor?: string
+    /** Filter to these seminar slugs; omit to show all published seminars */
+    seminarSlugs?: string[]
+    /** Whether to display a border around the widget (default: true) */
+    border?: boolean
+    /**
+     * When false and exactly one seminar is in scope, skip the list and open that seminar.
+     * Default: true (always show the list first when multiple seminars exist).
+     */
+    showListFirst?: boolean
+    /** Inherit font from parent page instead of using widget font (default: false) */
+    inheritFont?: boolean
+    /** Theme configuration for customizing colors and fonts */
+    theme?: TebutoWidgetTheme
+}


### PR DESCRIPTION
## Summary
- Add `TebutoSeminarsWidget` CDN wrapper for `seminars.js` with props → `data-*` mapping (`seminarSlugs`, `showListFirst`, theme, border, inheritFont)
- Jest coverage, Storybook stories, README/AGENTS sync docs; bump package to 1.4.0

## Test plan
- [x] `pnpm test` (96 tests)
- [x] `pnpm lint`
- [x] Storybook: Tebuto Seminars Widget stories load
- [x] After merge: npm publish 1.4.0 and bump tebuto monorepo submodule pointer to main