### PR TITLE
Add missing booking widget config options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ When the booking or seminars embed contract changes in tebuto (`data-*` attribut
 3. Update the README props tables.
 4. Merge/release, then bump the `react-booking-widget/` submodule pointer in the tebuto monorepo.
 
-Source of truth for attribute names: `webapp/src/widget/booking-render.tsx` and `webapp/src/widget/seminars-render.tsx`.
+Source of truth for attribute names: `webapp/src/widget/render.tsx` and `webapp/src/widget/seminars-render.tsx`.
 
 ## Local checks
 

--- a/README.md
+++ b/README.md
@@ -76,17 +76,21 @@ function BookingPage() {
 
 ### Props Reference
 
-| Prop               | Type                | Required | Default         | Description                                 |
-| ------------------ | ------------------- | -------- | --------------- | ------------------------------------------- |
-| `therapistUUID`    | `string`            | Yes      | -               | Unique identifier for the therapist         |
-| `backgroundColor`  | `string`            | No       | `transparent`   | Background color (hex, rgb, etc.)           |
-| `border`           | `boolean`           | No       | `true`          | Show border around the widget               |
-| `categories`       | `number[]`          | No       | `[]`            | Filter appointments by category IDs         |
-| `includeSubusers`  | `boolean`           | No       | `false`         | Include subuser appointments                |
-| `showQuickFilters` | `boolean`           | No       | `false`         | Show quick filter buttons for time slots    |
-| `inheritFont`      | `boolean`           | No       | `false`         | Use parent page font instead of widget font |
-| `theme`            | `TebutoWidgetTheme` | No       | -               | Theme customization object                  |
-| `noScriptText`     | `string`            | No       | Default message | Text shown when JavaScript is disabled      |
+| Prop                         | Type                | Required | Default         | Description                                              |
+| ---------------------------- | ------------------- | -------- | --------------- | -------------------------------------------------------- |
+| `therapistUUID`              | `string`            | Yes      | -               | Unique identifier for the therapist                      |
+| `backgroundColor`            | `string`            | No       | `transparent`   | Background color (hex, rgb, etc.)                        |
+| `border`                     | `boolean`           | No       | `true`          | Show border around the widget                            |
+| `categories`                 | `number[]`          | No       | `[]`            | Filter appointments by category IDs                      |
+| `includeSubusers`            | `boolean`           | No       | `false`         | Include subuser appointments                             |
+| `showQuickFilters`           | `boolean`           | No       | `false`         | Show quick filter buttons for time slots                 |
+| `showLocationQuickFilter`    | `boolean`           | No       | `false`         | Show city/place quick filter                             |
+| `showCategorySelectionFirst` | `boolean`           | No       | `true`          | Show category selection before the calendar              |
+| `showTherapistProfile`       | `boolean`           | No       | `false`         | Show therapist profile on category selection             |
+| `profileUrl`                 | `string`            | No       | -               | Optional therapist profile link                          |
+| `inheritFont`                | `boolean`           | No       | `false`         | Use parent page font instead of widget font              |
+| `theme`                      | `TebutoWidgetTheme` | No       | -               | Theme customization object                               |
+| `noScriptText`               | `string`            | No       | Default message | Text shown when JavaScript is disabled                   |
 
 ### Theme Configuration
 

--- a/src/components/TebutoBookingWidget.stories.tsx
+++ b/src/components/TebutoBookingWidget.stories.tsx
@@ -17,6 +17,16 @@ function applyScriptDataAttributes(script: HTMLScriptElement, config: TebutoBook
     if (config.border !== undefined) script.dataset.border = String(config.border)
     if (config.includeSubusers !== undefined) script.dataset.includeSubusers = String(config.includeSubusers)
     if (config.showQuickFilters !== undefined) script.dataset.showQuickFilters = String(config.showQuickFilters)
+    if (config.showLocationQuickFilter !== undefined) {
+        script.dataset.showLocationQuickFilter = String(config.showLocationQuickFilter)
+    }
+    if (config.showCategorySelectionFirst !== undefined) {
+        script.dataset.showCategorySelectionFirst = String(config.showCategorySelectionFirst)
+    }
+    if (config.showTherapistProfile !== undefined) {
+        script.dataset.showTherapistProfile = String(config.showTherapistProfile)
+    }
+    if (config.profileUrl) script.dataset.profileUrl = config.profileUrl
 
     const inheritFont = config.inheritFont ?? config.theme?.inheritFont
     if (inheritFont !== undefined) script.dataset.inheritFont = String(inheritFont)
@@ -131,6 +141,16 @@ function buildHtmlDataAttributes(config: TebutoBookingWidgetConfiguration): stri
     if (config.border !== undefined) attrs.push(`data-border="${config.border}"`)
     if (config.includeSubusers !== undefined) attrs.push(`data-include-subusers="${config.includeSubusers}"`)
     if (config.showQuickFilters !== undefined) attrs.push(`data-show-quick-filters="${config.showQuickFilters}"`)
+    if (config.showLocationQuickFilter !== undefined) {
+        attrs.push(`data-show-location-quick-filter="${config.showLocationQuickFilter}"`)
+    }
+    if (config.showCategorySelectionFirst !== undefined) {
+        attrs.push(`data-show-category-selection-first="${config.showCategorySelectionFirst}"`)
+    }
+    if (config.showTherapistProfile !== undefined) {
+        attrs.push(`data-show-therapist-profile="${config.showTherapistProfile}"`)
+    }
+    if (config.profileUrl) attrs.push(`data-profile-url="${config.profileUrl}"`)
 
     const inheritFont = config.inheritFont ?? config.theme?.inheritFont
     if (inheritFont !== undefined) attrs.push(`data-inherit-font="${inheritFont}"`)
@@ -220,6 +240,10 @@ so you can see the real widget working without a backend connection.
 - **categories**: Filter by category IDs
 - **includeSubusers**: Include team member appointments
 - **showQuickFilters**: Show time-of-day quick filters
+- **showLocationQuickFilter**: Show city/place quick filter
+- **showCategorySelectionFirst**: Show category selection before the calendar
+- **showTherapistProfile**: Show therapist profile on category selection
+- **profileUrl**: Optional therapist profile link
 - **theme**: Custom theming options`
             }
         }
@@ -256,6 +280,26 @@ so you can see the real widget working without a backend connection.
             description: 'Show time-of-day quick filter buttons',
             table: { category: 'Features' }
         },
+        showLocationQuickFilter: {
+            control: 'boolean',
+            description: 'Show city/place quick filter buttons',
+            table: { category: 'Features' }
+        },
+        showCategorySelectionFirst: {
+            control: 'boolean',
+            description: 'Show category selection before opening the calendar',
+            table: { category: 'Features' }
+        },
+        showTherapistProfile: {
+            control: 'boolean',
+            description: 'Show therapist profile on category selection',
+            table: { category: 'Features' }
+        },
+        profileUrl: {
+            control: 'text',
+            description: 'Optional therapist profile URL',
+            table: { category: 'Features' }
+        },
         inheritFont: {
             control: 'boolean',
             description: 'Use parent page font instead of widget font',
@@ -284,6 +328,25 @@ export const WithQuickFilters: Story = {
     args: {
         therapistUUID: DEMO_THERAPIST_UUID,
         showQuickFilters: true,
+        border: true
+    }
+}
+
+export const WithLocationQuickFilter: Story = {
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        includeSubusers: true,
+        showQuickFilters: true,
+        showLocationQuickFilter: true,
+        border: true
+    }
+}
+
+export const SkipCategorySelection: Story = {
+    args: {
+        therapistUUID: DEMO_THERAPIST_UUID,
+        categories: [1, 2],
+        showCategorySelectionFirst: false,
         border: true
     }
 }
@@ -398,6 +461,10 @@ export const FullyConfigured: Story = {
         border: true,
         includeSubusers: true,
         showQuickFilters: true,
+        showLocationQuickFilter: true,
+        showCategorySelectionFirst: false,
+        showTherapistProfile: true,
+        profileUrl: 'https://example.com/profile',
         theme: {
             primaryColor: '#6366f1',
             backgroundColor: '#fafafa',

--- a/src/components/TebutoBookingWidget.test.tsx
+++ b/src/components/TebutoBookingWidget.test.tsx
@@ -81,6 +81,28 @@ describe('TebutoBookingWidget', () => {
         expect(script.dataset.showQuickFilters).toBe('true')
     })
 
+    it('should set the "data-show-location-quick-filter" attribute when showLocationQuickFilter is true', () => {
+        render(<TebutoBookingWidget therapistUUID={therapistUUID} showLocationQuickFilter={true} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-booking-widget-script')
+        expect(script.dataset.showLocationQuickFilter).toBe('true')
+    })
+
+    it('should set the "data-show-category-selection-first" attribute when showCategorySelectionFirst is false', () => {
+        render(<TebutoBookingWidget therapistUUID={therapistUUID} showCategorySelectionFirst={false} />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-booking-widget-script')
+        expect(script.dataset.showCategorySelectionFirst).toBe('false')
+    })
+
+    it('should set therapist profile attributes when configured', () => {
+        render(<TebutoBookingWidget therapistUUID={therapistUUID} showTherapistProfile={true} profileUrl="https://example.com/profile" />)
+
+        const script = screen.getByTestId<HTMLScriptElement>('tebuto-booking-widget-script')
+        expect(script.dataset.showTherapistProfile).toBe('true')
+        expect(script.dataset.profileUrl).toBe('https://example.com/profile')
+    })
+
     it('should set the "data-inherit-font" attribute when inheritFont is true', () => {
         render(<TebutoBookingWidget therapistUUID={therapistUUID} inheritFont={true} />)
 
@@ -165,6 +187,10 @@ describe('TebutoBookingWidget', () => {
         expect(script.dataset.border).toBeUndefined()
         expect(script.dataset.includeSubusers).toBeUndefined()
         expect(script.dataset.showQuickFilters).toBeUndefined()
+        expect(script.dataset.showLocationQuickFilter).toBeUndefined()
+        expect(script.dataset.showCategorySelectionFirst).toBeUndefined()
+        expect(script.dataset.showTherapistProfile).toBeUndefined()
+        expect(script.dataset.profileUrl).toBeUndefined()
         expect(script.dataset.inheritFont).toBeUndefined()
         expect(script.dataset.primaryColor).toBeUndefined()
     })

--- a/src/components/TebutoBookingWidget.tsx
+++ b/src/components/TebutoBookingWidget.tsx
@@ -22,6 +22,10 @@ type DataAttributes = {
     'data-border'?: string
     'data-include-subusers'?: string
     'data-show-quick-filters'?: string
+    'data-show-location-quick-filter'?: string
+    'data-show-category-selection-first'?: string
+    'data-show-therapist-profile'?: string
+    'data-profile-url'?: string
     'data-inherit-font'?: string
     'data-primary-color'?: string
     'data-text-primary'?: string
@@ -43,6 +47,18 @@ function addBooleanAttributes(attributes: DataAttributes, config: TebutoBookingW
         attributes['data-show-quick-filters'] = config.showQuickFilters ? 'true' : 'false'
     }
 
+    if (config.showLocationQuickFilter !== undefined) {
+        attributes['data-show-location-quick-filter'] = config.showLocationQuickFilter ? 'true' : 'false'
+    }
+
+    if (config.showCategorySelectionFirst !== undefined) {
+        attributes['data-show-category-selection-first'] = config.showCategorySelectionFirst ? 'true' : 'false'
+    }
+
+    if (config.showTherapistProfile !== undefined) {
+        attributes['data-show-therapist-profile'] = config.showTherapistProfile ? 'true' : 'false'
+    }
+
     const inheritFont = config.inheritFont ?? config.theme?.inheritFont
     if (inheritFont !== undefined) {
         attributes['data-inherit-font'] = inheritFont ? 'true' : 'false'
@@ -61,6 +77,10 @@ function buildDataAttributes(config: TebutoBookingWidgetConfiguration): DataAttr
 
     if (config.categories && config.categories.length > 0) {
         attributes['data-categories'] = config.categories.join(',')
+    }
+
+    if (config.profileUrl) {
+        attributes['data-profile-url'] = config.profileUrl
     }
 
     addBooleanAttributes(attributes, config)

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,20 @@ export type TebutoBookingWidgetConfiguration = {
     includeSubusers?: boolean
     /** Show quick filter buttons for time slots (default: false) */
     showQuickFilters?: boolean
+    /**
+     * Show a quick place/city filter (management accounts with multiple cities).
+     * Default: false
+     */
+    showLocationQuickFilter?: boolean
+    /**
+     * When true (default), visitors pick a category first if multiple categories are available.
+     * Set to false to open the calendar directly.
+     */
+    showCategorySelectionFirst?: boolean
+    /** Show the therapist profile section on category selection (default: false) */
+    showTherapistProfile?: boolean
+    /** Optional URL used as the therapist profile link when showTherapistProfile is enabled */
+    profileUrl?: string
     /** Inherit font from parent page instead of using widget font (default: false) */
     inheritFont?: boolean
     /** Theme configuration for customizing colors and fonts */


### PR DESCRIPTION
## Summary
- Expose the remaining booking.js embed options on `TebutoBookingWidget` (`showLocationQuickFilter`, `showCategorySelectionFirst`, `showTherapistProfile`, `profileUrl`) so the React package matches the HTML/WordPress embed contract.

## Test plan
- [x] `pnpm test` / booking widget unit tests pass
- [x] Generated React snippet from the app settings wizard includes the new props when enabled